### PR TITLE
Hook SecurityGroupPolicy so it is installed before the Deployment

### DIFF
--- a/helm/templates/securitygrouppolicy-proteus-aws-operator-controller-manager.yaml
+++ b/helm/templates/securitygrouppolicy-proteus-aws-operator-controller-manager.yaml
@@ -4,6 +4,8 @@ kind: SecurityGroupPolicy
 metadata:
   name: proteus-aws-operator
   namespace: ack-system
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
 spec:
   serviceAccountSelector:
     matchLabels:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add a helm pre-install/pre-upgrade hook annotation to SecurityGroupPolicy so it is installed before the Deployment

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#8

## Motivation and Context

SecurityGroupPolicy will get installed before the Deployment so the Deployment won't fail.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
